### PR TITLE
Add a background dim On Clicking How To Play

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,10 @@
 
 <body>
   <div id="app " >
-    <div class="layout" ></div>
-    <div class="container " >
+    <div class="layout"  ></div>
+    <div class="container " id="Contai" >
       <header>Wordle</header>
-      <h2 id="How_to_play" >How to play</h2>
+      <h2  >How to play</h2>
       <div class="game-box"></div>
       <h3 class="lose">You're out of tries :(</h3>
       <h3 class="answer"></h3>

--- a/index.html
+++ b/index.html
@@ -1,34 +1,37 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Wordle</title>
-    <link rel="stylesheet" href="./style.css" />
-    <script type="module" src="./main.js" defer></script>
-  </head>
-  <body>
-    <div id="app">
-      <div class="layout"></div>
-      <div class="container">
-        <header>Wordle</header>
-        <h2>How to play</h2>
-        <div class="game-box"></div>
-        <h3 class="lose">You're out of tries :(</h3>
-        <h3 class="answer"></h3>
-        <h3 class="again">Play Again</h3>
-      </div>
-      <div class="guide">
-        <h2>Guess the word in 6 tries or less!</h2>
-        <p class="instructions">
-          The letters which are highlighted in
-          <strong id="blue">Blue</strong> constitute the word but are at the
-          wrong position. <strong id="green">Green</strong>letters are at the
-          correct position. Unhighlighted letters do not belong to the word.
-          Press Enter/Return to submit! Have fun :)
-        </p>
-      </div>
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Wordle</title>
+  <link rel="stylesheet" href="./style.css" />
+  <script type="module" src="./main.js"></script>
+</head>
+
+<body>
+  <div id="app " >
+    <div class="layout" ></div>
+    <div class="container " >
+      <header>Wordle</header>
+      <h2 id="How_to_play" >How to play</h2>
+      <div class="game-box"></div>
+      <h3 class="lose">You're out of tries :(</h3>
+      <h3 class="answer"></h3>
+      <h3 class="again">Play Again</h3>
     </div>
-  </body>
+    <div class="guide">
+      <h2>Guess the word in 6 tries or less!</h2>
+      <p class="instructions">
+        The letters which are highlighted in
+        <strong id="blue">Blue</strong> constitute the word but are at the
+        wrong position. <strong id="green">Green</strong>letters are at the
+        correct position. Unhighlighted letters do not belong to the word.
+        Press Enter/Return to submit! Have fun :)
+      </p>
+    </div>
+  </div>
+</body>
+
 </html>

--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
-import { Words } from "./words";
+import { Words } from "./words.js";
+
 
 const gameBox = document.querySelector(".game-box");
 const layout = document.querySelector(".layout");
@@ -7,6 +8,9 @@ const guide = document.querySelector(".guide");
 const playAgain = document.querySelector("h3.again");
 const lose = document.querySelector("h3.lose");
 const answer = document.querySelector("h3.answer");
+var body = document.body;
+
+const how_to_play=document.getElementById("how_to_play");
 
 let actual = Words[Math.floor(Math.random() * Words.length)].toLowerCase();
 let cache = new Map();
@@ -22,9 +26,14 @@ const layoutArray = [
 h2.onclick = (e) => {
   e.stopPropagation();
   guide.style.display = "block";
+  body.style.backgroundColor ="rgb(0, 0,0,0.8)";
+  body.style.cursor = "pointer"; 
+  
   document.addEventListener("click", (e) => {
     if (!e.target.closest(".guide")) {
       guide.style.display = "none";
+      body.style.backgroundColor = "white";
+   
     }
   });
 };

--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@ const guide = document.querySelector(".guide");
 const playAgain = document.querySelector("h3.again");
 const lose = document.querySelector("h3.lose");
 const answer = document.querySelector("h3.answer");
+const container=document.getElementById('Contai');
 var body = document.body;
 
 const how_to_play=document.getElementById("how_to_play");
@@ -26,14 +27,16 @@ const layoutArray = [
 h2.onclick = (e) => {
   e.stopPropagation();
   guide.style.display = "block";
-  body.style.backgroundColor ="rgb(0, 0,0,0.8)";
+  body.style.backgroundColor ="rgb(0, 0,0,0.6)";
   body.style.cursor = "pointer"; 
-  
+  layout.style.filter="blur(5px)";
+  container.style.filter="blur(5px)";
   document.addEventListener("click", (e) => {
     if (!e.target.closest(".guide")) {
       guide.style.display = "none";
       body.style.backgroundColor = "white";
-   
+      layout.style.filter="blur(0)";
+      container.style.filter="blur(0px)";
     }
   });
 };

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "start": "node main.js",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"

--- a/style.css
+++ b/style.css
@@ -139,10 +139,3 @@ h3.answer {
     bottom: 7.2rem;
   }
 }
-#How_to_play:hover{
-   border:2px solid black;
-  cursor: pointer;
-  height: 50px;
-  background-color: rgb(212, 195, 98);
-  color:black;
-}

--- a/style.css
+++ b/style.css
@@ -139,3 +139,10 @@ h3.answer {
     bottom: 7.2rem;
   }
 }
+#How_to_play:hover{
+   border:2px solid black;
+  cursor: pointer;
+  height: 50px;
+  background-color: rgb(212, 195, 98);
+  color:black;
+}


### PR DESCRIPTION
# Fixes Issue #1 

# 👨‍💻 Changes proposed(What did you do ?)-->
 Hover the  button when user click on button `How to play` And Become Dim. As Giving It Focus On Text Telling How to play.

# ✔️ Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [X] This PR does not contain plagiarized content.
- [X] The title and description of the PR is clear and explains the approach.



<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots
![Screenshot 2023-09-30 215956](https://github.com/swagatmitra-b/Wordle-in-JS/assets/99749401/b697c224-29d9-4b08-8662-a3e8504ca5c0)
![Screenshot 2023-09-30 220004](https://github.com/swagatmitra-b/Wordle-in-JS/assets/99749401/86639ab7-9858-4f47-8655-b12af7b57873)
![Screenshot 2023-09-30 220016](https://github.com/swagatmitra-b/Wordle-in-JS/assets/99749401/ba470cba-2281-44a0-adbd-775dcd5c40ea)

<!-- Add all the screenshots which support your changes -->
